### PR TITLE
Java wrapping added for text module

### DIFF
--- a/modules/text/CMakeLists.txt
+++ b/modules/text/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories(${Tesseract_INCLUDE_DIR})
 endif()
 
 set(the_description "Text Detection and Recognition")
-ocv_define_module(text opencv_ml opencv_highgui opencv_imgproc opencv_core opencv_features2d WRAP python)
+ocv_define_module(text opencv_ml opencv_highgui opencv_imgproc opencv_core opencv_features2d WRAP java python)
 
 if(${Tesseract_FOUND})
   target_link_libraries(opencv_text ${Tesseract_LIBS})


### PR DESCRIPTION
Commit 67a2066c4b411897f7a4f12c9ae921cfec45e660 states "Java and python wrappers for contrib modules" for the CMakeLists.txt file. This commit adds java actually. Just tested, jar includes all text module wrappers.
